### PR TITLE
Fix ghost suggestion sizing and acceptance controls

### DIFF
--- a/dayplannermacos/DayPlanner/App/Calendar/CalendarPanel.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/CalendarPanel.swift
@@ -58,7 +58,8 @@ struct CalendarPanel: View {
                 EnhancedDayView(
                     selectedDate: $selectedDate,
                     ghostSuggestions: $ghostSuggestions,
-                    showingRecommendations: $showingRecommendations
+                    showingRecommendations: $showingRecommendations,
+                    onAcceptanceInfoChange: handleGhostAcceptanceInfo
                 )
                     .frame(maxHeight: showingTodoList ? nil : .infinity)
                     .transition(.asymmetric(
@@ -105,15 +106,6 @@ struct CalendarPanel: View {
             .padding(.horizontal, 32)
             .padding(.bottom, 24) // Increased from 18 to 24 for more breathing room
         }
-        .onPreferenceChange(GhostAcceptancePreferenceKey.self) { info in
-            if reduceMotion {
-                ghostAcceptanceInfo = info
-            } else {
-                withAnimation(.spring(response: 0.6, dampingFraction: 0.85)) {
-                    ghostAcceptanceInfo = info
-                }
-            }
-        }
         .onChange(of: showingRecommendations) { _, enabled in
             if !enabled {
                 ghostAcceptanceInfo = nil
@@ -122,6 +114,18 @@ struct CalendarPanel: View {
         .onChange(of: showingMonthView) { _, isMonth in
             if isMonth {
                 ghostAcceptanceInfo = nil
+            }
+        }
+    }
+}
+
+private extension CalendarPanel {
+    func handleGhostAcceptanceInfo(_ info: GhostAcceptanceInfo?) {
+        if reduceMotion {
+            ghostAcceptanceInfo = info
+        } else {
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.85)) {
+                ghostAcceptanceInfo = info
             }
         }
     }

--- a/dayplannermacos/DayPlanner/App/Calendar/GhostOverlay.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/GhostOverlay.swift
@@ -54,8 +54,11 @@ private struct GhostEventCard: View {
     }
     
     private var eventHeight: CGFloat {
-        let computed = CGFloat(suggestion.duration / 60) * minuteHeight
-        return max(computed, 44)
+        let verticalPadding: CGFloat = 20
+        let minimumTotalHeight: CGFloat = 44
+        let rawTotalHeight = CGFloat(suggestion.duration / 60) * minuteHeight
+        let adjustedTotalHeight = max(rawTotalHeight, minimumTotalHeight)
+        return max(adjustedTotalHeight - verticalPadding, 0)
     }
     
     private var checkboxSymbol: String {

--- a/dayplannermacos/DayPlanner/Docs/CODE_MAP.md
+++ b/dayplannermacos/DayPlanner/Docs/CODE_MAP.md
@@ -738,7 +738,6 @@ This document is auto-generated to outline the primary declarations in each Swif
 
 ### EnhancedDayView.swift
 - L5: `struct GhostAcceptanceInfo`
-- L16: `struct GhostAcceptancePreferenceKey`
 - L27: `struct EnhancedDayView`
 - L167: `func handleBlockDrop`
 - L187: `func makeDiagnosticsSuggestions`


### PR DESCRIPTION
## Summary
- adjust ghost suggestion card layout so visual height matches suggested duration
- push ghost acceptance state changes to the calendar panel via a direct callback so the accept bar stays available
- update the code map documentation after removing the unused preference key

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6fb98b4e083338a33cef4ce7c7790