### PR TITLE
Improve calendar confirmations and ghost handling

### DIFF
--- a/dayplannermacos/DayPlanner/App/Calendar/CalendarChatBar.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/CalendarChatBar.swift
@@ -213,6 +213,12 @@ struct CalendarChatBar: View {
     }
     
     private func sendPlanningMessage(_ message: String) {
+        if let localAnswer = dataManager.localCalendarAnswer(for: message, on: dataManager.appState.currentDay.date) {
+            lastAIResponse = localAnswer
+            refreshPrompt()
+            return
+        }
+
         isSending = true
         lastAIResponse = nil // Clear previous response
         Task {

--- a/dayplannermacos/DayPlanner/App/Calendar/GhostOverlay.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/GhostOverlay.swift
@@ -8,7 +8,8 @@ struct GhostOverlay: View {
     let suggestions: [Suggestion]
     @Binding var selectedGhosts: Set<UUID>
     let onToggle: (Suggestion) -> Void
-    
+    let onReject: (Suggestion) -> Void
+
     var body: some View {
         ForEach(suggestions) { suggestion in
             GhostEventCard(
@@ -17,7 +18,8 @@ struct GhostOverlay: View {
                 dayStartHour: dayStartHour,
                 minuteHeight: minuteHeight,
                 isSelected: selectedGhosts.contains(suggestion.id),
-                onToggle: { onToggle(suggestion) }
+                onToggle: { onToggle(suggestion) },
+                onReject: { onReject(suggestion) }
             )
             .transition(reduceMotion ? .identity : .opacity.combined(with: .scale(scale: 0.98)))
         }
@@ -36,11 +38,12 @@ private struct GhostEventCard: View {
     let minuteHeight: CGFloat
     let isSelected: Bool
     let onToggle: () -> Void
-    
+    let onReject: () -> Void
+
     @EnvironmentObject private var dataManager: AppDataManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovering = false
-    
+
     private var calendar: Calendar { Calendar.current }
     
     private var startOfTimeline: Date {
@@ -146,7 +149,8 @@ private struct GhostEventCard: View {
     }
 
     var body: some View {
-        Button(action: onToggle) {
+        HStack(alignment: .top, spacing: 10) {
+            // Selection indicator and content
             HStack(alignment: .top, spacing: 10) {
                 Image(systemName: checkboxSymbol)
                     .font(.title3)
@@ -165,8 +169,8 @@ private struct GhostEventCard: View {
                         VStack(alignment: .trailing, spacing: 2) {
                             Text(suggestion.suggestedTime.timeString)
                                 .font(.caption2)
-                                .foregroundStyle(Color.white.opacity(0.7))
-                            
+                            .foregroundStyle(Color.white.opacity(0.7))
+
                             // Add visual hint for interaction
                             if !isSelected {
                                 Text("Tap to select")
@@ -176,7 +180,7 @@ private struct GhostEventCard: View {
                             }
                         }
                     }
-                    
+
                     HStack(spacing: 8) {
                         TagView(
                             text: "\(Int(suggestion.duration / 60))m",
@@ -206,26 +210,38 @@ private struct GhostEventCard: View {
                     }
                 }
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(backgroundColor)
-                    .blur(radius: 0.2)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .strokeBorder(style: StrokeStyle(lineWidth: 1.2, dash: [6, 6], dashPhase: 6))
-                            .foregroundStyle(borderColor)
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-            )
-            .shadow(color: Color.black.opacity(0.18), radius: 6, x: 0, y: 4)
+            Spacer(minLength: 0)
+
+            Button(action: onReject) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(Color.white.opacity(0.8))
+                    .symbolRenderingMode(.hierarchical)
+                    .padding(4)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text("Dismiss suggestion"))
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(backgroundColor)
+                .blur(radius: 0.2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1.2, dash: [6, 6], dashPhase: 6))
+                        .foregroundStyle(borderColor)
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+        )
+        .shadow(color: Color.black.opacity(0.18), radius: 6, x: 0, y: 4)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onToggle)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text(accessibilitySummary))

--- a/dayplannermacos/DayPlanner/App/Calendar/PreciseEventCard.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/PreciseEventCard.swift
@@ -15,8 +15,12 @@ struct FixedPositionEventCard: View {
     @State private var dragOffset: CGSize = .zero
     @State private var isDragging = false
     @State private var showingDetails = false
-    
+
     private let calendar = Calendar.current
+
+    private var displayTitle: String {
+        block.confirmationState == .confirmed ? "🔒 \(block.title)" : block.title
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -41,12 +45,12 @@ struct FixedPositionEventCard: View {
                     
                     // Block content
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(block.title)
+                        Text(displayTitle)
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.primary)
                             .lineLimit(durationBasedLineLimit)
-                        
+
                         HStack(spacing: 4) {
                             Text(block.startTime.timeString)
                                 .font(.caption)
@@ -778,13 +782,17 @@ struct CleanEventCard: View {
     let block: TimeBlock
     let onDrag: (CGPoint) -> Void
     let onDrop: (Date) -> Void
-    
+
     @EnvironmentObject private var dataManager: AppDataManager
     @State private var dragOffset: CGSize = .zero
     @State private var isDragging = false
     @State private var showingDetails = false
-    
+
     private let calendar = Calendar.current
+
+    private var displayTitle: String {
+        block.confirmationState == .confirmed ? "🔒 \(block.title)" : block.title
+    }
     
     var body: some View {
         Button(action: { showingDetails = true }) {
@@ -801,12 +809,12 @@ struct CleanEventCard: View {
                 
                 // Block content
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(block.title)
+                    Text(displayTitle)
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .foregroundStyle(.primary)
                         .lineLimit(1)
-                    
+
                     HStack(spacing: 4) {
                         Text(block.startTime.timeString)
                             .font(.caption)
@@ -1002,12 +1010,16 @@ struct EnhancedTimeBlockCard: View {
     let onDrag: (CGPoint) -> Void
     let onDrop: (Date) -> Void
     let allBlocks: [TimeBlock] // For chain gap checking
-    
+
     @EnvironmentObject private var dataManager: AppDataManager
     @State private var dragOffset: CGSize = .zero
     @State private var isDragging = false
     @State private var showingDetails = false
     @State private var activeTab: EventTab = .details
+
+    private var displayTitle: String {
+        block.confirmationState == .confirmed ? "🔒 \(block.title)" : block.title
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -1025,12 +1037,12 @@ struct EnhancedTimeBlockCard: View {
                 
                     // Block content
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(block.title)
+                    Text(displayTitle)
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .foregroundStyle(.primary)
                         .lineLimit(2)
-                    
+
                     HStack(spacing: 6) {
                         Text(timeString(from: block.startTime))
                             .font(.caption)

--- a/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
@@ -13,6 +13,7 @@ struct ProportionalTimelineView: View {
     private let showGhosts: Bool
     private let ghostSuggestions: [Suggestion]
     private let onGhostToggle: (Suggestion) -> Void
+    private let onGhostReject: (Suggestion) -> Void
     private let calendar = Calendar.current
     private let dayStartHour: Int
     private let dayEndHour: Int
@@ -41,7 +42,8 @@ struct ProportionalTimelineView: View {
         dayStartHour: Int = 0,
         dayEndHour: Int = 24,
         selectedGhosts: Binding<Set<UUID>> = .constant([]),
-        onGhostToggle: @escaping (Suggestion) -> Void = { _ in }
+        onGhostToggle: @escaping (Suggestion) -> Void = { _ in },
+        onGhostReject: @escaping (Suggestion) -> Void = { _ in }
     ) {
         self.selectedDate = selectedDate
         self.blocks = blocks
@@ -56,6 +58,7 @@ struct ProportionalTimelineView: View {
         self.dayEndHour = dayEndHour
         _selectedGhosts = selectedGhosts
         self.onGhostToggle = onGhostToggle
+        self.onGhostReject = onGhostReject
     }
     
     private var currentHour: Int {
@@ -107,7 +110,8 @@ struct ProportionalTimelineView: View {
                         minuteHeight: minuteHeight,
                         suggestions: ghostSuggestions,
                         selectedGhosts: $selectedGhosts,
-                        onToggle: onGhostToggle
+                        onToggle: onGhostToggle,
+                        onReject: onGhostReject
                     )
                 }
             }

--- a/dayplannermacos/DayPlanner/Data/Models.swift
+++ b/dayplannermacos/DayPlanner/Data/Models.swift
@@ -603,6 +603,27 @@ struct Suggestion: Identifiable, Codable {
     }
 }
 
+/// Lightweight memory for recently rejected suggestions so the AI can be more considerate
+struct SuggestionRejectionMemory: Identifiable, Codable, Hashable {
+    var id: UUID = UUID()
+    var title: String
+    var suggestedTime: Date
+    var rejectedAt: Date
+    var reason: String?
+
+    /// Stored slot identifier so we can avoid proposing the exact same window repeatedly
+    var slotIdentifier: String
+
+    init(id: UUID = UUID(), title: String, suggestedTime: Date, rejectedAt: Date = Date(), reason: String? = nil, slotIdentifier: String) {
+        self.id = id
+        self.title = title
+        self.suggestedTime = suggestedTime
+        self.rejectedAt = rejectedAt
+        self.reason = reason
+        self.slotIdentifier = slotIdentifier
+    }
+}
+
 /// Context for AI decision making
 struct DayContext: Codable {
     let date: Date
@@ -671,7 +692,8 @@ struct AppState: Codable {
     var todoItems: [TodoItem] = []
     var moodEntries: [MoodEntry] = []
     var onboarding: OnboardingState = OnboardingState()
-    
+    var suggestionRejections: [SuggestionRejectionMemory] = []
+
     // Scheduling emphasis and feedback signals
     var pinnedGoalIds: Set<UUID> = []
     var emphasizedPillarIds: Set<UUID> = []
@@ -730,7 +752,11 @@ struct Record: Identifiable, Codable {
     var energy: EnergyType
     var emoji: String
     var confirmedAt: Date = Date()
-    
+    var confirmationNote: String?
+    var weatherSnapshot: String?
+    var moodSnapshot: GlassMood?
+    var observationLog: [String] = []
+
     var duration: TimeInterval {
         endTime.timeIntervalSince(startTime)
     }


### PR DESCRIPTION
## Summary
- capture richer confirmation records, surface local day summaries, and display lock icons on confirmed blocks
- add suggestion rejection memory plus a dismiss affordance for ghost recommendations to request alternative slots
- respect AI-provided event start times by parsing schedule data and adjusting past timestamps forward when needed

## Testing
- Not run (macOS Xcode project without Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68d70a256ad08333a305267c36e2574c