### PR TITLE
Add current time awareness to AI planning context

### DIFF
--- a/dayplannermacos/DayPlanner/AI/AIService.swift
+++ b/dayplannermacos/DayPlanner/AI/AIService.swift
@@ -393,7 +393,7 @@ class AIService: ObservableObject {
         SMART INTENT ANALYSIS: Analyze this user message to determine the BEST action with HIGH ACCURACY: "\(message)"
         
         Context:
-        - Current time: \(context.date.formatted(.dateTime.hour().minute()))
+        - Current local time: \(context.currentTime.formatted(.dateTime.hour().minute()))
         - Existing blocks: \(context.existingBlocks.count)
         - Available time: \(Int(context.availableTime/3600)) hours
         - Current energy: \(context.currentEnergy.description)
@@ -889,7 +889,8 @@ class AIService: ObservableObject {
         You are a helpful day planning assistant. The user is planning their day and needs suggestions.
         
         Current context:
-        - Date & Time: \(context.date.formatted(.dateTime.weekday().month().day().year().hour().minute()))
+        - Planning for: \(context.date.formatted(.dateTime.weekday().month().day().year()))
+        - Current local time: \(context.currentTime.formatted(.dateTime.hour().minute().timeZone()))
         - Current energy: \(context.currentEnergy.description)
         - Existing activities: \(context.existingBlocks.count)
         - Available time: \(Int(context.availableTime/3600)) hours
@@ -1467,7 +1468,8 @@ class AIService: ObservableObject {
         You are a helpful day planning assistant. The user is asking for suggestions: "\(message)"
         
         Current context:
-        - Date & Time: \(context.date.formatted(.dateTime.weekday().month().day().year().hour().minute()))
+        - Planning for: \(context.date.formatted(.dateTime.weekday().month().day().year()))
+        - Current local time: \(context.currentTime.formatted(.dateTime.hour().minute().timeZone()))
         - Current energy: \(context.currentEnergy.description)
         - Existing activities: \(context.existingBlocks.count)
         - Available time: \(Int(context.availableTime/3600)) hours

--- a/dayplannermacos/DayPlanner/Data/Models.swift
+++ b/dayplannermacos/DayPlanner/Data/Models.swift
@@ -606,6 +606,7 @@ struct Suggestion: Identifiable, Codable, Equatable {
 /// Context for AI decision making
 struct DayContext: Codable {
     let date: Date
+    let currentTime: Date
     let existingBlocks: [TimeBlock]
     let currentEnergy: EnergyType
     let preferredEmojis: [String]
@@ -613,9 +614,18 @@ struct DayContext: Codable {
     let mood: GlassMood
     let weatherContext: String?
     let pillarGuidance: [String]
-    
-    init(date: Date, existingBlocks: [TimeBlock], currentEnergy: EnergyType, preferredEmojis: [String], availableTime: TimeInterval, mood: GlassMood, weatherContext: String? = nil, pillarGuidance: [String] = []) {
+
+    init(date: Date,
+         currentTime: Date = Date(),
+         existingBlocks: [TimeBlock],
+         currentEnergy: EnergyType,
+         preferredEmojis: [String],
+         availableTime: TimeInterval,
+         mood: GlassMood,
+         weatherContext: String? = nil,
+         pillarGuidance: [String] = []) {
         self.date = date
+        self.currentTime = currentTime
         self.existingBlocks = existingBlocks
         self.currentEnergy = currentEnergy
         self.preferredEmojis = preferredEmojis
@@ -628,6 +638,7 @@ struct DayContext: Codable {
     var summary: String {
         var summary = """
         Date: \(date.formatted(date: .abbreviated, time: .omitted))
+        Current Time: \(currentTime.formatted(date: .omitted, time: .shortened))
         Energy: \(currentEnergy.description)
         Blocks: \(existingBlocks.count)
         Available: \(Int(availableTime/3600))h

--- a/dayplannermacos/DayPlanner/Data/Storage.swift
+++ b/dayplannermacos/DayPlanner/Data/Storage.swift
@@ -1234,6 +1234,7 @@ class AppDataManager: ObservableObject {
 
         return DayContext(
             date: date,
+            currentTime: Date(),
             existingBlocks: allRelevantBlocks,
             currentEnergy: determineCurrentEnergy(),
             preferredEmojis: extractPreferredEmojis(),


### PR DESCRIPTION
## Summary
- add a dedicated currentTime value to DayContext so the assistant always receives the live clock information
- update AI prompt templates to surface both the selected planning date and the user's current local time (with timezone)
- refresh the stored context summary and context builder to capture the new timestamp data

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7152009448333adae97ed0bf9631c