### PR TITLE
Improve ghost suggestion dismissal experience

### DIFF
--- a/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
@@ -13,6 +13,7 @@ struct ProportionalTimelineView: View {
     private let showGhosts: Bool
     private let ghostSuggestions: [Suggestion]
     private let onGhostToggle: (Suggestion) -> Void
+    private let onGhostDismiss: (Suggestion) -> Void
     private let calendar = Calendar.current
     private let dayStartHour: Int
     private let dayEndHour: Int
@@ -41,7 +42,8 @@ struct ProportionalTimelineView: View {
         dayStartHour: Int = 0,
         dayEndHour: Int = 24,
         selectedGhosts: Binding<Set<UUID>> = .constant([]),
-        onGhostToggle: @escaping (Suggestion) -> Void = { _ in }
+        onGhostToggle: @escaping (Suggestion) -> Void = { _ in },
+        onGhostDismiss: @escaping (Suggestion) -> Void = { _ in }
     ) {
         self.selectedDate = selectedDate
         self.blocks = blocks
@@ -56,6 +58,7 @@ struct ProportionalTimelineView: View {
         self.dayEndHour = dayEndHour
         _selectedGhosts = selectedGhosts
         self.onGhostToggle = onGhostToggle
+        self.onGhostDismiss = onGhostDismiss
     }
     
     private var currentHour: Int {
@@ -107,7 +110,8 @@ struct ProportionalTimelineView: View {
                         minuteHeight: minuteHeight,
                         suggestions: ghostSuggestions,
                         selectedGhosts: $selectedGhosts,
-                        onToggle: onGhostToggle
+                        onToggle: onGhostToggle,
+                        onDismiss: onGhostDismiss
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- add a reusable schedule fingerprint plus rejection memory to capture dismissed time slots
- surface a dismiss button on ghost suggestions, refresh recommendations after removal, and align card height with duration
- incorporate rejection penalties into suggestion prioritization so ghosts avoid recently skipped times

## Testing
- not run (macOS build environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d71f142f8483339b0d2f65d7b6ca9e