### PR TITLE
Improve calendar chat scheduling and confirmations

### DIFF
--- a/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
+++ b/dayplannermacos/DayPlanner/App/Calendar/ProportionalTimelineView.swift
@@ -524,10 +524,10 @@ struct PreciseEventCard: View {
         }
         .overlay(alignment: .topTrailing) {
             if block.confirmationState == .confirmed {
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.caption2)
-                    .foregroundStyle(.green)
+                Text("🔒")
+                    .font(.title3)
                     .padding(6)
+                    .accessibilityLabel("Confirmed")
             }
         }
         .onHover { hovering in


### PR DESCRIPTION
## Summary
- resolve event creation start times from AI responses so calendar chat schedules on the intended day and time
- capture confirmation replies as lock-stamped notes with weather context and feed completions into the pattern engine
- replace the checkmark badge with a lock icon on confirmed blocks to reflect their locked state

## Testing
- not run (macOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d71ede7cc083338110346a88138e76